### PR TITLE
SSC Interface: pointer member variables are not deleted inside destructor

### DIFF
--- a/as/include/as/ssc_interface.h
+++ b/as/include/as/ssc_interface.h
@@ -67,13 +67,13 @@ private:
   ros::Subscriber vehicle_cmd_sub_;
   ros::Subscriber engage_sub_;
   ros::Subscriber module_states_sub_;
-  message_filters::Subscriber<automotive_platform_msgs::VelocityAccelCov>* velocity_accel_sub_;
-  message_filters::Subscriber<automotive_platform_msgs::CurvatureFeedback>* curvature_feedback_sub_;
-  message_filters::Subscriber<automotive_platform_msgs::ThrottleFeedback>* throttle_feedback_sub_;
-  message_filters::Subscriber<automotive_platform_msgs::BrakeFeedback>* brake_feedback_sub_;
-  message_filters::Subscriber<automotive_platform_msgs::GearFeedback>* gear_feedback_sub_;
-  message_filters::Subscriber<automotive_platform_msgs::SteeringFeedback>* steering_wheel_sub_;
-  message_filters::Synchronizer<SSCFeedbacksSyncPolicy>* ssc_feedbacks_sync_;
+  message_filters::Subscriber<automotive_platform_msgs::VelocityAccelCov> velocity_accel_sub_;
+  message_filters::Subscriber<automotive_platform_msgs::CurvatureFeedback> curvature_feedback_sub_;
+  message_filters::Subscriber<automotive_platform_msgs::ThrottleFeedback> throttle_feedback_sub_;
+  message_filters::Subscriber<automotive_platform_msgs::BrakeFeedback> brake_feedback_sub_;
+  message_filters::Subscriber<automotive_platform_msgs::GearFeedback> gear_feedback_sub_;
+  message_filters::Subscriber<automotive_platform_msgs::SteeringFeedback> steering_wheel_sub_;
+  std::unique_ptr<message_filters::Synchronizer<SSCFeedbacksSyncPolicy>> ssc_feedbacks_sync_;
 
   // publishers
   ros::Publisher steer_mode_pub_;
@@ -111,7 +111,6 @@ private:
   ros::Time command_time_;
   autoware_msgs::VehicleCmd vehicle_cmd_;
   automotive_navigation_msgs::ModuleState module_states_;
-  ros::Rate* rate_;
 
   // callbacks
   void callbackFromVehicleCmd(const autoware_msgs::VehicleCmdConstPtr& msg);

--- a/as/src/ssc_interface.cpp
+++ b/as/src/ssc_interface.cpp
@@ -37,29 +37,21 @@ SSCInterface::SSCInterface() : nh_(), private_nh_("~"), engage_(false), command_
   private_nh_.param<double>("agr_coef_b", agr_coef_b_, 0.053);
   private_nh_.param<double>("agr_coef_c", agr_coef_c_, 0.042);
 
-  rate_ = new ros::Rate(loop_rate_);
-
   // subscribers from autoware
   vehicle_cmd_sub_ = nh_.subscribe("vehicle_cmd", 1, &SSCInterface::callbackFromVehicleCmd, this);
   engage_sub_ = nh_.subscribe("vehicle/engage", 1, &SSCInterface::callbackFromEngage, this);
 
   // subscribers from SSC
   module_states_sub_ = nh_.subscribe("ssc/module_states", 1, &SSCInterface::callbackFromSSCModuleStates, this);
-  curvature_feedback_sub_ =
-      new message_filters::Subscriber<automotive_platform_msgs::CurvatureFeedback>(nh_, "ssc/curvature_feedback", 10);
-  throttle_feedback_sub_ =
-      new message_filters::Subscriber<automotive_platform_msgs::ThrottleFeedback>(nh_, "ssc/throttle_feedback", 10);
-  brake_feedback_sub_ =
-      new message_filters::Subscriber<automotive_platform_msgs::BrakeFeedback>(nh_, "ssc/brake_feedback", 10);
-  gear_feedback_sub_ =
-      new message_filters::Subscriber<automotive_platform_msgs::GearFeedback>(nh_, "ssc/gear_feedback", 10);
-  velocity_accel_sub_ =
-      new message_filters::Subscriber<automotive_platform_msgs::VelocityAccelCov>(nh_, "ssc/velocity_accel_cov", 10);
-  steering_wheel_sub_ =
-      new message_filters::Subscriber<automotive_platform_msgs::SteeringFeedback>(nh_, "ssc/steering_feedback", 10);
-  ssc_feedbacks_sync_ = new message_filters::Synchronizer<SSCFeedbacksSyncPolicy>(
-      SSCFeedbacksSyncPolicy(10), *velocity_accel_sub_, *curvature_feedback_sub_, *throttle_feedback_sub_,
-      *brake_feedback_sub_, *gear_feedback_sub_, *steering_wheel_sub_);
+  curvature_feedback_sub_.subscribe(nh_, "ssc/curvature_feedback", 10);
+  throttle_feedback_sub_.subscribe(nh_, "ssc/throttle_feedback", 10);
+  brake_feedback_sub_.subscribe(nh_, "ssc/brake_feedback", 10);
+  gear_feedback_sub_.subscribe(nh_, "ssc/gear_feedback", 10);
+  velocity_accel_sub_.subscribe(nh_, "ssc/velocity_accel_cov", 10);
+  steering_wheel_sub_.subscribe(nh_, "ssc/steering_feedback", 10);
+  ssc_feedbacks_sync_.reset(new message_filters::Synchronizer<SSCFeedbacksSyncPolicy>(
+      SSCFeedbacksSyncPolicy(10), velocity_accel_sub_, curvature_feedback_sub_, throttle_feedback_sub_,
+      brake_feedback_sub_, gear_feedback_sub_, steering_wheel_sub_));
   ssc_feedbacks_sync_->registerCallback(
       boost::bind(&SSCInterface::callbackFromSSCFeedbacks, this, _1, _2, _3, _4, _5, _6));
 
@@ -80,6 +72,8 @@ void SSCInterface::run()
   ShmVitalMonitor shm_ROvmon("RosObserver", loop_rate_);
   ShmVitalMonitor shm_HAvmon("HealthAggregator", loop_rate_);
 
+  ros::Rate rate(loop_rate_);
+
   while (ros::ok())
   {
     ros::spinOnce();
@@ -94,7 +88,7 @@ void SSCInterface::run()
 
     publishCommand();
 
-    rate_->sleep();
+    rate.sleep();
   }
 }
 


### PR DESCRIPTION
Transferred from GitLab. See original PR for details: https://gitlab.com/autowarefoundation/autoware.ai/drivers/-/merge_requests/34 
